### PR TITLE
Remove normal font weight from headings

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -53,10 +53,6 @@ header + main {
 
 }
 
-h1, h2, h3 {
-  font-weight: normal;
-}
-
 body > header h1 {
   font-weight: bold;
   font-size:3.2rem;
@@ -68,7 +64,6 @@ h2 {
     line-height: 1.4;
     margin-top:2.3125rem;
     margin-bottom:1.3125rem;
-    font-weight:normal;
 }
 h2 + * {
     margin-top:0.2em;


### PR DESCRIPTION
Make sure all headers are both as per the registered pages

### Before
<img width="1336" alt="screen shot 2017-01-12 at 16 14 01" src="https://cloud.githubusercontent.com/assets/3071606/21897665/36852896-d8e2-11e6-89e1-8eebef1c1573.png">

### After
<img width="1336" alt="screen shot 2017-01-12 at 16 14 03" src="https://cloud.githubusercontent.com/assets/3071606/21897653/30054adc-d8e2-11e6-901a-174767efe02c.png">
