### PR TITLE
Swap the default link and :visited colours around

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -107,11 +107,11 @@ p {
 }
 
 a {
-  color:#4c2c92;
+  color: #005ea5;
 }
 
 a:visited {
-  color:#005ea5;
+  color: #4c2c92;
 }
 
 a:hover,


### PR DESCRIPTION
Browsers default to blue for links and purple for visited links, so the current opposite setup is confusing.

Example of current look and feel (with the GDS and GDS Technology blogs visited):

<img width="723" alt="" src="https://user-images.githubusercontent.com/7414/29862558-260be302-8d6d-11e7-9c6c-c7473df4591a.png">

The same section with the change from this PR:

<img width="716" alt="" src="https://user-images.githubusercontent.com/7414/29862585-3483006e-8d6d-11e7-9b39-c83d359e9049.png">
